### PR TITLE
添加“发送群消息，并在指定方法执行后撤回”

### DIFF
--- a/Mirai.Net/Utils/Scaffolds/MiraiScaffold.cs
+++ b/Mirai.Net/Utils/Scaffolds/MiraiScaffold.cs
@@ -172,6 +172,24 @@ public static class MiraiScaffold
     }
 
     /// <summary>
+    ///  发送群消息，并在指定方法执行后撤回
+    /// </summary>
+    /// <param name="receiver"></param>
+    /// <param name="chain">消息链</param>
+    /// <param name="action">要执行的方法</param>
+    /// <returns></returns>
+    public static async Task<string> SendRecallAfterMethod(this GroupMessageReceiver receiver,
+        MessageChain chain, Func<Task> action)
+    {
+        string messageId = await MessageManager
+            .SendGroupMessageAsync(receiver.Sender.Group.Id, chain);
+        await action();
+        await MessageManager
+            .RecallAsync(messageId, receiver.GroupId);
+        return messageId;
+    }
+
+    /// <summary>
     ///     发送好友消息
     /// </summary>
     /// <param name="receiver"></param>


### PR DESCRIPTION
添加“发送群消息，并在指定方法执行后撤回”

> 用于机器人发送加载提示，并及时撤回

# 使用示例
```
await receiver.SendRecallAfterMethod("操作中请稍后···", async () => {

                // 任何操作
                await receiver.SendMessageAsync("已成功执行");
            });
```

模拟场景：
memberA: 查询名称
bot: 查询中···
bot:你的名称是A
···
然后撤回查询中发言