### PR TITLE
BUG修复 属性添加 方法添加 支持输入控制台指令 注释修改

### DIFF
--- a/Mirai.Net/Data/Messages/Concretes/ForwardMessage.cs
+++ b/Mirai.Net/Data/Messages/Concretes/ForwardMessage.cs
@@ -19,7 +19,7 @@ public record ForwardMessage : MessageBase
     /// 点进消息前的显示内容
     /// </summary>
     [JsonProperty("display")]
-    public ForwardDisplay Display { get; set; } = default;
+    public ForwardDisplay Display { get; set; }
 
     /// <summary>
     ///     消息节点
@@ -93,6 +93,27 @@ public record ForwardMessage : MessageBase
     public record ForwardDisplay
     {
         /// <summary>
+        ///     生成转发消息的外层显示
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="brief"></param>
+        /// <param name="source"></param>
+        /// <param name="preview"></param>
+        /// <param name="summary"></param>
+        public ForwardDisplay(string title = default, string brief = default, string source = default, IEnumerable<string> preview = default, string summary = default)
+        {
+            this.Title = title;
+
+            this.Brief = brief;
+
+            this.Source = source;
+
+            this.Preview = preview;
+
+            this.Summary = summary;
+        }
+
+        /// <summary>
         ///     标题
         /// </summary>
         [JsonProperty("title")]
@@ -121,6 +142,5 @@ public record ForwardMessage : MessageBase
         /// </summary>
         [JsonProperty("summary")]
         public string Summary { get; set; }
-
     }
 }

--- a/Mirai.Net/Data/Messages/Concretes/MusicShareMessage.cs
+++ b/Mirai.Net/Data/Messages/Concretes/MusicShareMessage.cs
@@ -13,7 +13,7 @@ public record MusicShareMessage : MessageBase
     public override Messages Type { get; set; } = Messages.MusicShare;
 
     /// <summary>
-    /// 类型
+    /// 类型，即分享自的软件平台
     /// </summary>
     [JsonProperty("kind")] public string Kind { get; set; }
 

--- a/Mirai.Net/Data/Messages/Concretes/PokeMessage.cs
+++ b/Mirai.Net/Data/Messages/Concretes/PokeMessage.cs
@@ -3,7 +3,7 @@
 namespace Mirai.Net.Data.Messages.Concretes;
 
 /// <summary>
-/// 我也不知道是啥玩意
+/// 戳一戳系列消息
 /// </summary>
 public record PokeMessage : MessageBase
 {

--- a/Mirai.Net/Data/Messages/MessageBase.cs
+++ b/Mirai.Net/Data/Messages/MessageBase.cs
@@ -45,7 +45,7 @@ public record MessageBase
             case ImageMessage msg:
 
                 if (string.IsNullOrEmpty(msg.ImageId))
-                    throw new("ImageId为空！");
+                    throw new System.ArgumentNullException("ImageId为空！");
 
                 else
                     return $"[mirai:image:{msg.ImageId}]";
@@ -61,7 +61,7 @@ public record MessageBase
             case FaceMessage msg:
 
                 if (string.IsNullOrEmpty(msg.FaceId))
-                    throw new("FaceId为空！");
+                    throw new System.ArgumentNullException("FaceId为空！");
 
                 else
                     return $"[mirai:face:{msg.FaceId}]";
@@ -82,7 +82,7 @@ public record MessageBase
 
                     "FangDaZhao" => "放大招,6,-1",
 
-                    _ => throw new("该Poke消息还未支持！")
+                    _ => throw new System.NotSupportedException("该Poke消息还未支持！")
                 };
 
                 return $"[mirai:poke:{poke}]";
@@ -91,7 +91,7 @@ public record MessageBase
 
                 return $"[mirai:dice:{msg.Value}]";
 
-            case MusicShareMessage msg: // MusicShare在mirai的2.15.0-M1版本中显示为[mirai:origin:MUSIC_SHARE]MusicShare(*这里有一长串省略的内容) 与https://github.com/mamoe/mirai/blob/dev/docs/Messages.md中所说的[mirai:musicshare:$args]不符 因此这里先采用后者的方式 使用半角逗号分隔 至少保证序列化的稳定
+            case MusicShareMessage msg: // MusicShare在mirai的2.15.0-M1版本中显示为[mirai:origin:MUSIC_SHARE]MusicShare(*这里有一长串省略的内容) 与https://github.com/mamoe/mirai/blob/dev/docs/Messages.md 中所说的[mirai:musicshare:$args]不符 因此这里先采用后者的方式 使用半角逗号分隔 至少保证序列化的稳定
 
                 return $"[mirai:musicshare:{msg.Kind},{msg.Title},{msg.Summary},{msg.JumpUrl},{msg.PictureUrl},{msg.MusicUrl},{msg.Brief}]";
 
@@ -101,7 +101,7 @@ public record MessageBase
 
             default:
 
-                throw new("遇到了不支持序列化的消息！");
+                throw new System.NotSupportedException("遇到了不支持序列化的消息！");
         }
     }
 

--- a/Mirai.Net/Mirai.Net.csproj
+++ b/Mirai.Net/Mirai.Net.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.4.9</PackageVersion>
+        <PackageVersion>2.5.0</PackageVersion>
         <Title>Mirai.Net</Title>
         <LangVersion>latest</LangVersion>
         <Description>基于mirai-api-http的轻量级mirai社区sdk</Description>

--- a/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
+++ b/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
@@ -78,6 +78,23 @@ namespace Mirai.Net.Sessions.Http.Managers
         /// <para>命令与参数</para>
         /// </param>
         /// <returns></returns>
+        public static async Task ExecuteCommandAsync(string commands)
+        {
+            var command = new PlainMessage(commands);
+
+            await HttpEndpoints.ExecuteCommand.PostJsonAsync(new
+            {
+                command
+            });
+        }
+
+        /// <summary>
+        /// 执行命令
+        /// </summary>
+        /// <param name="commands">
+        /// <para>命令与参数</para>
+        /// </param>
+        /// <returns></returns>
         public static async Task ExecuteCommandAsync(params string[] commands)
         {
             var builder = new System.Text.StringBuilder();

--- a/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
+++ b/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
@@ -32,19 +32,8 @@ namespace Mirai.Net.Sessions.Http.Managers
         public static async Task LoginAsync(string qq, string password, Protocol? protocol = null)
         {
             var command = protocol is null
-                ? new PlainMessage[]
-                {
-                    "/login",
-                    qq,
-                    password
-                }
-                : new PlainMessage[]
-                {
-                    "/login",
-                    qq,
-                    password,
-                    protocol.ToString()
-                };
+                ? new PlainMessage[] { $"/login {qq} {password}" }
+                : new PlainMessage[] { $"/login {qq} {password} {protocol.ToString()}" };
 
             await HttpEndpoints.ExecuteCommand.PostJsonAsync(new
             {
@@ -74,7 +63,7 @@ namespace Mirai.Net.Sessions.Http.Managers
         /// <returns></returns>
         public static async Task LogoutAsync(string qq)
         {
-            var command = new PlainMessage[] { "/logout", qq };
+            var command = new PlainMessage[] { $"/logout {qq}" };
 
             await HttpEndpoints.ExecuteCommand.PostJsonAsync(new
             {

--- a/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
+++ b/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
@@ -20,7 +20,10 @@ namespace Mirai.Net.Sessions.Http.Managers
     {
 #nullable enable
         /// <summary>
-        /// 登录指令
+        /// <para>登录指令</para>
+        /// <para>登录后的账号会生成新的SessionKey 使用已有的MiraiBot实例是无法连接到该账号的</para>
+        /// <para>如果配置相同（QQ Address VerifyKey）可以再次在同一个MiraiBot上使用LaunchAsync方法之后就可以正常使用了</para>
+        /// <para>在LaunchAsync之前使用的任何Subscribe方法都不会应用于新登录的账号 必须重新Subscribe</para>
         /// </summary>
         /// <param name="qq"></param>
         /// <param name="password"></param>

--- a/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
+++ b/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
@@ -80,7 +80,7 @@ namespace Mirai.Net.Sessions.Http.Managers
         /// <returns></returns>
         public static async Task ExecuteCommandAsync(string commands)
         {
-            var command = new PlainMessage(commands);
+            var command = new PlainMessage[] { commands };
 
             await HttpEndpoints.ExecuteCommand.PostJsonAsync(new
             {

--- a/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
+++ b/Mirai.Net/Sessions/Http/Managers/ConsoleManager.cs
@@ -29,7 +29,7 @@ namespace Mirai.Net.Sessions.Http.Managers
         /// <param name="password"></param>
         /// <param name="protocol"></param>
         /// <returns></returns>
-        public static async Task LoginAsync(string qq, string password, Protocol? protocol)
+        public static async Task LoginAsync(string qq, string password, Protocol? protocol = null)
         {
             var command = protocol is null
                 ? new PlainMessage[]

--- a/Mirai.Net/Utils/Scaffolds/MessageChain.cs
+++ b/Mirai.Net/Utils/Scaffolds/MessageChain.cs
@@ -69,16 +69,16 @@ public partial class MessageChain : List<MessageBase>
 #nullable enable
 
     /// <summary>
-    /// 获取该消息的消息来源 如果没有来源则返回null
+    /// 获取该消息的消息来源 如果有多个来源返回最后一个 如果没有来源则返回null
     /// </summary>
     /// <returns></returns>
-    public SourceMessage? GetSourceMessage() => this.OfType<SourceMessage>().FirstOrDefault();
+    public SourceMessage? GetSourceMessage() => this.OfType<SourceMessage>().LastOrDefault();
 
     /// <summary>
-    /// 获取该消息的消息引用 如果没有引用则返回null
+    /// 获取该消息的消息引用 如果有多个引用返回最后一个 如果没有引用则返回null
     /// </summary>
     /// <returns></returns>
-    public QuoteMessage? GetQuoteMessage() => this.OfType<QuoteMessage>().FirstOrDefault();
+    public QuoteMessage? GetQuoteMessage() => this.OfType<QuoteMessage>().LastOrDefault();
 
 #nullable disable
 

--- a/Mirai.Net/Utils/Scaffolds/MessageChain.cs
+++ b/Mirai.Net/Utils/Scaffolds/MessageChain.cs
@@ -75,7 +75,7 @@ public partial class MessageChain : List<MessageBase>
     public SourceMessage? GetSourceMessage() => this.OfType<SourceMessage>().FirstOrDefault();
 
     /// <summary>
-    /// 获取该消息的消息来源 如果没有引用则返回null
+    /// 获取该消息的消息引用 如果没有引用则返回null
     /// </summary>
     /// <returns></returns>
     public QuoteMessage? GetQuoteMessage() => this.OfType<QuoteMessage>().FirstOrDefault();
@@ -126,7 +126,7 @@ public partial class MessageChain : List<MessageBase>
     }
 
     /// <summary>
-    /// 将该消息链序列化为mirai码
+    /// 将该消息链序列化为mirai码 不会捕获异常
     /// </summary>
     /// <returns></returns>
     public string SerializeToMiraiCode()
@@ -202,18 +202,17 @@ public partial class MessageChain : List<MessageBase>
         {
             if (left[i].Type != right[i].Type) return false;
 
-            if (left[i].Type == Messages.Source || right[i].Type == Messages.Source)
-                continue;
-
             // 这段代码用了一种极其诡异的方法判断是否相等
-            // 首先检查能否转换为图片消息然后挨个判断四个属性 都不相等就返回false 有一个相等就返回true
+            // 首先检查能否转换为图片消息或者语音消息然后挨个判断四个属性 都不相等就返回false 有一个相等就返回true
             // 然后看不能转换的时候利用record直接判左右相等
             // 最后把前面所有的一切套进if里顺便加反转 如果为true什么都不做 如果为false直接返回false
             if (!((left[i], right[i]) switch
             {
-                (ImageMessage leftmsg, ImageMessage rightmsg) => (leftmsg.ImageId != rightmsg.ImageId && leftmsg.Url != rightmsg.Url && leftmsg.Path != rightmsg.Path && leftmsg.Base64 != rightmsg.Base64) ? false : true,
+                (ImageMessage leftmsg, ImageMessage rightmsg) => !(leftmsg.ImageId != rightmsg.ImageId && leftmsg.Url != rightmsg.Url && leftmsg.Path != rightmsg.Path && leftmsg.Base64 != rightmsg.Base64),
 
-                (var leftmsg, var rightmsg) => leftmsg == rightmsg ? true : false
+                (VoiceMessage leftmsg, VoiceMessage rightmsg) => !(leftmsg.VoiceId != rightmsg.VoiceId && leftmsg.Url != rightmsg.Url && leftmsg.Path != rightmsg.Path && leftmsg.Base64 != rightmsg.Base64),
+
+                (var leftmsg, var rightmsg) => leftmsg == rightmsg
             })) return false;
         }
 

--- a/Mirai.Net/Utils/Scaffolds/MessageChain.cs
+++ b/Mirai.Net/Utils/Scaffolds/MessageChain.cs
@@ -31,6 +31,29 @@ public partial class MessageChain : List<MessageBase>
     }
 
     /// <summary>
+    /// 运行时安全的Mirai码
+    /// </summary>
+    public string MiraiCode
+    {
+        get
+        {
+            System.Text.StringBuilder builder = new();
+
+            this.ForEach(x => 
+            {
+                try
+                {
+                    builder.Append(x.SerializeToMiraiCode());
+                }
+                catch
+                {}
+            });
+
+            return builder.ToString();
+        }
+    }
+
+    /// <summary>
     /// 获取消息链中的纯文本消息
     /// </summary>
     /// <returns>如果没有文本消息返回空字符串</returns>
@@ -46,7 +69,7 @@ public partial class MessageChain : List<MessageBase>
 #nullable enable
 
     /// <summary>
-    /// 获取该消息的消息来源 如果没有引用则返回null
+    /// 获取该消息的消息来源 如果没有来源则返回null
     /// </summary>
     /// <returns></returns>
     public SourceMessage? GetSourceMessage() => this.OfType<SourceMessage>().FirstOrDefault();
@@ -169,10 +192,11 @@ public partial class MessageChain : List<MessageBase>
     /// <returns></returns>
     public static bool operator ==(MessageChain left, MessageChain right)
     {
-        if (left.Count != right.Count) return false;
+        left = left.Where(x => x is not SourceMessage).ToMessageChain();
 
-        if ((left.OfType<MiraiCodeMessage>().FirstOrDefault()?.Code ?? left.SerializeToMiraiCode()) == (right.OfType<MiraiCodeMessage>().FirstOrDefault()?.Code ?? right.SerializeToMiraiCode()))
-            return true;
+        right = right.Where(x => x is not SourceMessage).ToMessageChain();
+
+        if (left.Count != right.Count) return false;
 
         for (int i = 0; i < left.Count; i++)
         {
@@ -203,7 +227,7 @@ public partial class MessageChain : List<MessageBase>
     /// <param name="left"></param>
     /// <param name="right"></param>
     /// <returns></returns>
-    public static bool operator !=(MessageChain left, MessageChain right) => left == right ? false : true;
+    public static bool operator !=(MessageChain left, MessageChain right) => !(left == right);
 
     /// <summary>
     /// 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mirai.Net 2.4.8
+# Mirai.Net 2.5.0
 
 Mirai.NET 是基于 [mirai-api-http] 实现的 C# 版轻量级 [mirai] 社区 SDK。
 


### PR DESCRIPTION
修改了一部分BUG

修改了MessageBase的SerializeToMiraiCode方法，当ImageMessage和FaceMessage的ImageId和FaceId为空时 不再抛出Exception而是System.ArgumentNullException（因为这俩只支持有ID的序列化），当PokeMessage遇到了[Poke](https://docs.mirai.mamoe.net/mirai-api-http/api/MessageType.html#poke)支持的六种消息类型以外的消息和遇到了不支持序列化的MessageBase序列化时会抛出System.NotSupportedException

给MessageChain添加了MiraiCode属性，使用MiraiCode会自动忽略那些不支持序列化的消息类型，可以用来比对某些消息是否相等

改进了MessageChain的==运算符

给ConsoleManager添加了Protocol枚举（只支持安卓手机 安卓平板 安卓手表 因为mirai http api文档写了只支持这仨） LoginAsync方法 StopAsync方法 LogoutAsync方法进行登录 退出MCL 登出操作 添加了ExecuteCommandAsync方法用于直接传入字符串或多个字符串执行MCL命令

优化了部分代码（指上次pr写出的? false : true逆天写法）

修复了部分注释

csproj和README的版本号改成了2.5.0（）