### PR TITLE
紧急BUG修复

### DIFF
--- a/Mirai.Net/Data/Messages/Concretes/ForwardMessage.cs
+++ b/Mirai.Net/Data/Messages/Concretes/ForwardMessage.cs
@@ -93,6 +93,12 @@ public record ForwardMessage : MessageBase
     public record ForwardDisplay
     {
         /// <summary>
+        /// 
+        /// </summary>
+        public ForwardDisplay()
+        {}
+
+        /// <summary>
         ///     生成转发消息的外层显示
         /// </summary>
         /// <param name="title"></param>

--- a/Mirai.Net/Mirai.Net.csproj
+++ b/Mirai.Net/Mirai.Net.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.5.0</PackageVersion>
+        <PackageVersion>2.5.1</PackageVersion>
         <Title>Mirai.Net</Title>
         <LangVersion>latest</LangVersion>
         <Description>基于mirai-api-http的轻量级mirai社区sdk</Description>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mirai.Net 2.5.0
+# Mirai.Net 2.5.1
 
 Mirai.NET 是基于 [mirai-api-http] 实现的 C# 版轻量级 [mirai] 社区 SDK。
 


### PR DESCRIPTION
由于缺少无参构造函数导致Mirai.Net.Utils.Internal命名空间下的ReflectionUtils类的GetDefaultInstances方法持续抛出异常，使GetMessageBase方法持续捕获异常导致所有类型的消息都变为Unknown类型，会导致诸如“收不到消息”类似的问题出现

版本号更新为2.5.1