### PR TITLE
一些issue的处理

### DIFF
--- a/Mirai.Net/Utils/Internal/ExceptionUtils.cs
+++ b/Mirai.Net/Utils/Internal/ExceptionUtils.cs
@@ -13,25 +13,25 @@ internal static class ExceptionUtils
     /// <returns></returns>
     internal static string OfErrorMessage(this string json)
     {
-        //todo: use is integer
-        var code = json.Fetch("code")?.ThrowIfNotInt64("错误的状态码").ToString();
+        // todo: use is integer
+        var code = json.Fetch("code")?.ThrowIfNotInt64("错误的状态码");
 
-        var vocabulary = new Dictionary<string, string>
+        return code switch
         {
-            { "0", "正确" },
-            { "1", "错误的verify key" },
-            { "2", "指定的Bot不存在" },
-            { "3", "Session失效或不存在" },
-            { "4", "Session未认证(未激活)" },
-            { "5", "发送消息目标不存在(指定对象不存在)" },
-            { "6", "指定文件不存在" },
-            { "10", "Bot没有对应操作的限权" },
-            { "20", "Bot被禁言" },
-            { "30", "消息过长" },
-            { "400", "错误的访问" },
-            { "500", "上传文件错误" }
+            0 => "成功", // Success : StateCode(0, "success") // 成功
+            1 => "错误的verify key", // AuthKeyFail : StateCode(1, "Auth Key错误")
+            2 => "指定的Bot不存在", // NoBot : StateCode(2, "指定Bot不存在")
+            3 => "Session失效或不存在", // IllegalSession : StateCode(3, "Session失效或不存在")
+            4 => "Session未认证", // NotVerifySession : StateCode(4, "Session未认证")
+            5 => "指定对象不存在", // NoElement : StateCode(5, "指定对象不存在")
+            6 => "指定操作不支持", // NoOperateSupport : StateCode(6, "指定操作不支持")
+            10 => "Bot没有对应操作的权限", // PermissionDenied : StateCode(10, "无操作权限")
+            20 => "Bot被禁言", // BotMuted : StateCode(20, "Bot被禁言")
+            30 => "消息过长", // MessageTooLarge : StateCode(30, "消息过长")
+            400 => "无效参数", // InvalidParameter : StateCode(400, "无效参数")
+            500 => "内部错误", // class InternalError() : StateCode(500, "")
+            _ => null // default case if code does not match any known codes
         };
-
-        return vocabulary.FirstOrDefault(x => x.Key == code).Value;
     }
+
 }

--- a/Mirai.Net/Utils/Internal/MiraiHttpUtils.cs
+++ b/Mirai.Net/Utils/Internal/MiraiHttpUtils.cs
@@ -5,13 +5,25 @@ using Mirai.Net.Data.Exceptions;
 using Mirai.Net.Data.Sessions;
 using Mirai.Net.Sessions;
 using Newtonsoft.Json;
+using System;
 using System.Threading.Tasks;
 using NullValueHandling = Newtonsoft.Json.NullValueHandling;
 
 namespace Mirai.Net.Utils.Internal;
 
-internal static class MiraiHttpUtils
+/// <summary>
+/// 用户自定义错误处理
+/// </summary>
+public delegate void ErrorHandler(Exception ex);
+/// <summary>
+/// 由于特定插件有自定义Endpoint的需求，因此有必要将PostJsonAsync与GetAsync整体暴露为public
+/// </summary>
+public static class MiraiHttpUtils
 {
+    /// <summary>
+    /// 用户自定义错误处理器
+    /// </summary>
+    public static ErrorHandler HttpErrorHandler { get; set; }
     #region Guarantee
 
     /// <summary>
@@ -51,18 +63,34 @@ internal static class MiraiHttpUtils
     /// <param name="url"></param>
     /// <param name="withSessionKey">是否添加session头</param>
     /// <returns></returns>
-    internal static async Task<string> GetAsync(string url, bool withSessionKey = true)
+    public static async Task<string> GetAsync(string url, bool withSessionKey = true)
     {
-        var result = withSessionKey
-            ? await url
-                .WithHeader("Authorization", $"session {MiraiBot.Instance.HttpSessionKey}")
-                .GetAsync()
-            : await url.GetAsync();
+        try
+        {
+            var result = withSessionKey
+                ? await url
+                    .WithHeader("Authorization", $"session {MiraiBot.Instance.HttpSessionKey}")
+                    .GetAsync()
+                : await url.GetAsync();
 
-        var re = await result.GetStringAsync();
-        re.EnsureSuccess($"url={url}");
+            var re = await result.GetStringAsync();
+            re.EnsureSuccess($"url={url}");
 
-        return re;
+            return re;
+        }
+        catch (Exception e)
+        {
+            if (HttpErrorHandler != null)
+            {
+                e.Data["method"] = "get";
+                e.Data["url"] = url;
+                HttpErrorHandler.Invoke(e); // 如果错误处理器不为 null，则调用
+            }
+
+            else
+                throw; // 否则，重新抛出异常
+            return null;
+        }
     }
 
     internal static async Task<string> GetAsync(this HttpEndpoints endpoints, object extra = null,
@@ -82,24 +110,41 @@ internal static class MiraiHttpUtils
     /// <param name="json"></param>
     /// <param name="withSessionKey">加入Authentication: session xxx 请求头</param>
     /// <returns></returns>
-    internal static async Task<string> PostJsonAsync(string url, object json, bool withSessionKey = true)
+    public static async Task<string> PostJsonAsync(string url, object json, bool withSessionKey = true)
     {
-        var result = withSessionKey
-            ? await url
-                .WithHeader("Authorization", $"session {MiraiBot.Instance.HttpSessionKey}")
-                .PostStringAsync(json.ToJsonString(new JsonSerializerSettings
+        try
+        {
+            var result = withSessionKey
+                ? await url
+                    .WithHeader("Authorization", $"session {MiraiBot.Instance.HttpSessionKey}")
+                    .PostStringAsync(json.ToJsonString(new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore
+                    }))
+                : await url.PostStringAsync(json.ToJsonString(new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore
-                }))
-            : await url.PostStringAsync(json.ToJsonString(new JsonSerializerSettings
+                }));
+
+            var re = await result.GetStringAsync();
+            re.EnsureSuccess($"url={url}\r\npayload={json.ToJsonString()}");
+
+            return re;
+        }
+        catch (Exception e)
+        {
+            if (HttpErrorHandler != null)
             {
-                NullValueHandling = NullValueHandling.Ignore
-            }));
+                e.Data["method"] = "post";
+                e.Data["url"] = url;
+                e.Data["json"] = json;
+                HttpErrorHandler.Invoke(e); // 如果错误处理器不为 null，则调用
+            }
 
-        var re = await result.GetStringAsync();
-        re.EnsureSuccess($"url={url}\r\npayload={json.ToJsonString()}");
-
-        return re;
+            else
+                throw; // 否则，重新抛出异常
+            return null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
修正OfErrorMessage的错误提示文字
公开MiraiHttpUtils中的PostJsonAsync与GetAsync方法，允许发送非标准EndPoints的请求
在InvalidResponseException的Data中提供更多的信息
允许用户传入自定义的错误处理方法，并通过`ex.Data["msg"]`等属性获得错误的具体信息
修复无法上传中文文件名群文件问题