### PR TITLE
在链式调用中增加.If()方法

### DIFF
--- a/Mirai.Net/Data/Messages/Concretes/ImageMessage.cs
+++ b/Mirai.Net/Data/Messages/Concretes/ImageMessage.cs
@@ -47,4 +47,22 @@ public record ImageMessage : MessageBase
     /// </summary>
     [JsonProperty("height")]
     public string Height { get; set; }
+
+    /// <summary>
+    ///     图片的大小，单位为字节
+    /// </summary>
+    [JsonProperty("size")]
+    public string Size { get; set; }
+
+    /// <summary>
+    ///     图片的类型
+    /// </summary>
+    [JsonProperty("imageType")]
+    public string ImageType { get; set; }
+
+    /// <summary>
+    ///     图片是否作为表情发送，QQ会根据该属性决定是否自动缩小显示的尺寸
+    /// </summary>
+    [JsonProperty("isEmoji")]
+    public string IsEmoji { get; set; }
 }

--- a/Mirai.Net/Utils/Scaffolds/MessageChainBuilder.cs
+++ b/Mirai.Net/Utils/Scaffolds/MessageChainBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Mirai.Net.Data.Messages;
 using Mirai.Net.Data.Messages.Concretes;
 using Mirai.Net.Data.Shared;
+using System;
 
 namespace Mirai.Net.Utils.Scaffolds;
 
@@ -10,6 +11,7 @@ namespace Mirai.Net.Utils.Scaffolds;
 public class MessageChainBuilder
 {
     private readonly MessageChain _chain = new();
+    private bool _skipNext = false;
 
     /// <summary>
     /// 清除已追加的消息
@@ -17,7 +19,7 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder Clear()
     {
-        _chain.Clear();
+        ExecuteOrSkip(_chain.Clear);
         return this;
     }
 
@@ -28,7 +30,7 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder Append(MessageBase messageBase)
     {
-        _chain.Add(messageBase);
+        ExecuteOrSkip(() => _chain.Add(messageBase));
         return this;
     }
 
@@ -39,7 +41,7 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder Plain(string text)
     {
-        _chain.Add(new PlainMessage(text));
+        ExecuteOrSkip(() => _chain.Add(new PlainMessage(text)));
         return this;
     }
 
@@ -50,7 +52,7 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder At(string qq)
     {
-        _chain.Add(new AtMessage(qq));
+        ExecuteOrSkip(() => _chain.Add(new AtMessage(qq)));
         return this;
     }
 
@@ -71,9 +73,11 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder App(string content)
     {
-        _chain.Add(new AppMessage
-        {
-            Content = content
+        ExecuteOrSkip(() => {
+            _chain.Add(new AppMessage
+            {
+                Content = content
+            });
         });
         return this;
     }
@@ -84,8 +88,7 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder AtAll()
     {
-        _chain.Add(new AtAllMessage());
-
+        ExecuteOrSkip(() => _chain.Add(new AtAllMessage()));
         return this;
     }
 
@@ -96,11 +99,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder Dice(string value)
     {
-        _chain.Add(new DiceMessage
-        {
-            Value = value
+        ExecuteOrSkip(() => {
+            _chain.Add(new DiceMessage
+            {
+                Value = value
+            });
         });
-
         return this;
     }
 
@@ -111,11 +115,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder ImageFromUrl(string url)
     {
-        _chain.Add(new ImageMessage
-        {
-            Url = url
+        ExecuteOrSkip(() => {
+            _chain.Add(new ImageMessage
+            {
+                Url = url
+            });
         });
-
         return this;
     }
 
@@ -126,11 +131,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder ImageFromBase64(string base64)
     {
-        _chain.Add(new ImageMessage
-        {
-            Base64 = base64
+        ExecuteOrSkip(() => {
+            _chain.Add(new ImageMessage
+            {
+                Base64 = base64
+            });
         });
-
         return this;
     }
 
@@ -141,11 +147,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder ImageFromPath(string file)
     {
-        _chain.Add(new ImageMessage
-        {
-            Path = file
+        ExecuteOrSkip(() => {
+            _chain.Add(new ImageMessage
+            {
+                Path = file
+            });
         });
-
         return this;
     }
 
@@ -156,11 +163,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder ImageFromId(string id)
     {
-        _chain.Add(new ImageMessage
-        {
-            ImageId = id
+        ExecuteOrSkip(() => {
+            _chain.Add(new ImageMessage
+            {
+                ImageId = id
+            });
         });
-
         return this;
     }
 
@@ -171,11 +179,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder FlashImageFromUrl(string url)
     {
-        _chain.Add(new FlashImageMessage
-        {
-            Url = url
+        ExecuteOrSkip(() => {
+            _chain.Add(new FlashImageMessage
+            {
+                Url = url
+            });
         });
-
         return this;
     }
 
@@ -186,11 +195,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder FlashImageFromBase64(string base64)
     {
-        _chain.Add(new FlashImageMessage
-        {
-            Base64 = base64
+        ExecuteOrSkip(() => {
+            _chain.Add(new FlashImageMessage
+            {
+                Base64 = base64
+            });
         });
-
         return this;
     }
 
@@ -201,11 +211,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder FlashImageFromPath(string file)
     {
-        _chain.Add(new FlashImageMessage
-        {
-            Path = file
+        ExecuteOrSkip(() => {
+            _chain.Add(new FlashImageMessage
+            {
+                Path = file
+            });
         });
-
         return this;
     }
 
@@ -216,11 +227,13 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder FlashImageFromId(string id)
     {
-        _chain.Add(new FlashImageMessage
+        ExecuteOrSkip(() =>
         {
-            ImageId = id
+            _chain.Add(new FlashImageMessage
+            {
+                ImageId = id
+            });
         });
-
         return this;
     }
 
@@ -231,11 +244,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder Json(string json)
     {
-        _chain.Add(new JsonMessage
-        {
-            Json = json
+        ExecuteOrSkip(() => {
+            _chain.Add(new JsonMessage
+            {
+                Json = json
+            });
         });
-
         return this;
     }
 
@@ -246,11 +260,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder Xml(string xml)
     {
-        _chain.Add(new XmlMessage
-        {
-            Xml = xml
+        ExecuteOrSkip(() => {
+            _chain.Add(new XmlMessage
+            {
+                Xml = xml
+            });
         });
-
         return this;
     }
 
@@ -261,11 +276,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder VoiceFromPath(string path)
     {
-        _chain.Add(new VoiceMessage
-        {
-            Path = path
+        ExecuteOrSkip(() => {
+            _chain.Add(new VoiceMessage
+            {
+                Path = path
+            });
         });
-
         return this;
     }
 
@@ -276,11 +292,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder VoiceFromBase64(string base64)
     {
-        _chain.Add(new VoiceMessage
-        {
-            Base64 = base64
+        ExecuteOrSkip(() => {
+            _chain.Add(new VoiceMessage
+            {
+                Base64 = base64
+            });
         });
-
         return this;
     }
 
@@ -291,11 +308,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder VoiceFromId(string id)
     {
-        _chain.Add(new VoiceMessage
-        {
-            VoiceId = id
+        ExecuteOrSkip(() => {
+            _chain.Add(new VoiceMessage
+            {
+                VoiceId = id
+            });
         });
-
         return this;
     }
 
@@ -306,11 +324,12 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChainBuilder VoiceFromUrl(string url)
     {
-        _chain.Add(new VoiceMessage
-        {
-            Url = url
+        ExecuteOrSkip(() => {
+            _chain.Add(new VoiceMessage
+            {
+                Url = url
+            });
         });
-
         return this;
     }
 
@@ -320,6 +339,25 @@ public class MessageChainBuilder
     /// <returns></returns>
     public MessageChain Build()
     {
+        //Build方法无视_skipNext的值，直接返回消息链
         return _chain;
+    }
+
+    /// <summary>
+    /// 判断条件，如果为false，则跳过下一个元素
+    /// </summary>
+    /// <returns></returns>
+    public MessageChainBuilder If(bool condition)
+    {
+        _skipNext = !condition;
+        return this;
+    }
+
+    // 中间方法，根据_skipNext的值决定是否执行传入的操作
+    private void ExecuteOrSkip(Action action)
+    {
+        if (!_skipNext) 
+            action.Invoke();
+        _skipNext = false;  // Reset the skip flag after each operation
     }
 }


### PR DESCRIPTION
MessageChainBuilder的改善，使得可以通过`.If(isAdmin).AtAll()...`这样的方式，通过条件判断来决定拼接还是忽略下一个元素。
这可以简化复杂的消息链拼接，尤其是在包含非纯文本的元素时，例如消息可能需要包含多张图片，以及前面提到的At全体等。你也可以`.Plain("123").If(true).Clear().Plain("456")`这样的方式，在必要的时候直接使用`Clear()`清除之前的内容。
```
_ = x.SendMessageAsync(new MessageChainBuilder()
    .Plain($"文字内容是{x.MessageChain.GetPlainMessage()}")
    .If(isVal).Plain("\n内容是数字！恭喜你获得了大奖！")
    .If(isAdmin).AtAll()
    .Build());
```
在之前，这种可能需要动态添加元素内容的情况只能手动构建MessageChain然后往里面Add元素，无法充分利用MessageChainBuilder的灵活性。在链式调用中添加If()可以极大地改善这种情况，让MessageChainBuilder的适用范围更广。

此改动不会影响原本的MessageChainBuilder的正常工作。